### PR TITLE
fix: Evitar Mensagens duplicadas

### DIFF
--- a/main.py
+++ b/main.py
@@ -49,7 +49,6 @@ class Initialize():
             confirmacao = input(f"Tem certeza de que deseja excluir o paciente com ID {id_paciente}? (s/n): ").lower()
             if confirmacao == 's':
                 p.excluirPaciente() 
-                print(f"Paciente com ID {id_paciente} foi excluído com sucesso.")
             else:
                 print("Operação de exclusão cancelada.")
         

--- a/models/consulta.py
+++ b/models/consulta.py
@@ -63,17 +63,18 @@ class Consulta:
         self.data = novos_dados.get("data", self.data)
 
         # Salva as alterações no armazenamento
-        self.__armazenamento.editar_consulta(
+        if self.__armazenamento.editar_consulta(
             self.id_consulta,
             self.descricao,
             self.paciente,
             self.lista_procedimentos,
-            self.data
-        )
-        print(f'Consulta com ID {self.id_consulta} atualizada com sucesso.')
+            self.data):
+            print(f'Consulta com ID {self.id_consulta} atualizada com sucesso.')
 
-        # Registra os dados no Log
-        Log.registrar_log(f"Consulta editada: {self.id_consulta}, {self.descricao}, Paciente: {self.paciente}, Data: {self.data}")
+            # Registra os dados no Log
+            Log.registrar_log(f"Consulta editada: {self.id_consulta}, {self.descricao}, Paciente: {self.paciente}, Data: {self.data}")
+        else:
+            print(f'Consulta com ID {self.id_consulta} nao encontrada.')
 
     def excluirConsulta(self):
         """Exclui uma consulta do armazenamento."""

--- a/models/paciente.py
+++ b/models/paciente.py
@@ -1,4 +1,5 @@
 from utils.armazenamento import Armazenamento
+from utils.log import Log
 
 class Paciente:
     contador_id = 1  # Inicializa com 1; pode ser alterado com base no maior ID existente

--- a/models/paciente.py
+++ b/models/paciente.py
@@ -39,13 +39,23 @@ class Paciente:
         self.sexo_paciente = novos_dados.get("sexo_paciente", self.sexo_paciente)
 
         # Salva as alterações no armazenamento
-        self.__armazenamento.editar_paciente(self.id_paciente, self.nome_paciente, self.data_nascimento, self.sexo_paciente)
-        print(f'Paciente {self.nome_paciente} com ID {self.id_paciente} atualizado com sucesso.')
+        if self.__armazenamento.editar_paciente(self.id_paciente, self.nome_paciente, self.data_nascimento, self.sexo_paciente):
+            print(f'Paciente {self.nome_paciente} com ID {self.id_paciente} atualizado com sucesso.')
+
+             # Registra os dados no Log
+            Log.registrar_log(f"Paciente inserido: {self.id_paciente}, {self.nome_paciente}, Data de Nascimento: {self.data_nascimento}, Sexo: {self.sexo_paciente}")
+        else:
+            print(f'Paciente com ID {self.id_paciente} nao encontrado.')
 
     def excluirPaciente(self):
         """Exclui o paciente do armazenamento."""
-        self.__armazenamento.remover_paciente(self.id_paciente)
-        print(f'Paciente com ID {self.id_paciente} foi excluído.')
+        if self.__armazenamento.remover_paciente(self.id_paciente):
+            print(f'Paciente com ID {self.id_paciente} foi excluído.')
+
+            # Registra os dados no Log
+            Log.registrar_log(f"Paciente excluído: {self.id_paciente}")
+        else:
+            print(f'Paciente com ID {self.id_paciente} não foi encontrado.' )
 
     def consultarPaciente(self):
         """Consulta as informações do paciente no armazenamento."""

--- a/models/procedimento.py
+++ b/models/procedimento.py
@@ -56,12 +56,13 @@ class Procedimento:
         self.descricao_procedimento = novos_dados.get("descricao_procedimento", self.descricao_procedimento)
 
         # Salva as alterações no armazenamento (arquivo)
-        self.__armazenamento.editar_procedimento(self.id_procedimento, self.nome_procedimento, self.descricao_procedimento)
+        if self.__armazenamento.editar_procedimento(self.id_procedimento, self.nome_procedimento, self.descricao_procedimento):
+            print(f'Procedimento {self.nome_procedimento} com ID {self.id_procedimento} atualizado com sucesso.')
 
-        print(f'Procedimento {self.nome_procedimento} com ID {self.id_procedimento} atualizado com sucesso.')
-
-        #Registra os dados no Log 
-        Log.registrar_log(f"Procedimento editado: {self.id_procedimento}, {self.nome_procedimento}, {self.descricao_procedimento}")
+            #Registra os dados no Log 
+            Log.registrar_log(f"Procedimento editado: {self.id_procedimento}, {self.nome_procedimento}, {self.descricao_procedimento}")
+        else:
+            print(f'Procedimento com ID {self.id_procedimento} nao encontrado.')
 
         
     def excluir_procedimento(self):

--- a/utils/armazenamento.py
+++ b/utils/armazenamento.py
@@ -45,8 +45,7 @@ class Armazenamento():
                 sexo = campos[3]
                 return nome, data_nascimento, sexo
 
-        print('Paciente nao encontrado')
-        return None, None, None, None  
+        return None
 
 
     def editar_paciente(self, id_paciente, nome_paciente=None, data_nascimento=None, sexo_paciente=None):
@@ -83,14 +82,13 @@ class Armazenamento():
                     continue
 
         if not paciente_encontrado:
-            print(f"Paciente com ID {id_paciente} não encontrado.")
-            return
+            return False
 
         # Reescreve o arquivo com as alterações
         with open(self.arquivo_pacientes, 'w') as f:
             f.writelines(linhas)
 
-        print(f"Paciente com ID {id_paciente} atualizado com sucesso.")
+        return True
 
 
     def remover_paciente(self, id_paciente):
@@ -115,8 +113,7 @@ class Armazenamento():
 
         # Verifica se o paciente foi encontrado
         if indice_paciente is None:
-            print('Paciente não encontrado.')
-            return
+            return False
 
         # Remove a linha correspondente ao paciente
         del linhas[indice_paciente]
@@ -128,7 +125,7 @@ class Armazenamento():
         with open(self.arquivo_pacientes, 'w') as f:
             f.writelines(linhas)
 
-        print(f"Paciente com ID {id_paciente} removido com sucesso.")
+        return True
 
     def salvar_procedimento(self, id_procedimento, nome_procedimento, descricao_procedimento):
         '''Adiciona uma linha no arquivo de procedimentos'''
@@ -151,7 +148,6 @@ class Armazenamento():
                     
                     return nome, descricao # TODO: retornar classe
 
-        print('Procedimento nao encontrado')
         return None
 
           
@@ -180,9 +176,10 @@ class Armazenamento():
         if procedimento_encontrado:
             with open(self.arquivo_procedimentos, 'w') as f:
                 f.writelines(linhas)
-            print(f'Procedimento {id_procedimento} atualizado com sucesso.')
+
+            return True
         else:
-            print(f'Procedimento com ID {id_procedimento} não encontrado.')
+            return False
             
 
 
@@ -204,7 +201,6 @@ class Armazenamento():
                 break 
 
         if indice_procedimento is None:
-            print('Procedimento não encontrado.')
             return False  
 
         del linhas[indice_procedimento]
@@ -239,7 +235,6 @@ class Armazenamento():
 
                     return descricao, paciente, lista_procedimentos, data
 
-        print('Consulta não encontrada.')
         return None
 
     def editar_consulta(self, id_consulta, descricao=None, paciente=None, lista_procedimentos=None, data=None):
@@ -267,9 +262,10 @@ class Armazenamento():
         if consulta_encontrada:
             with open(self.arquivo_consultas, 'w') as f:
                 f.writelines(linhas)
-            print(f'Consulta {id_consulta} atualizada com sucesso.')
+
+            return True
         else:
-            print(f'Consulta com ID {id_consulta} não encontrada.')
+            return False
 
 
     def remover_consulta(self, codigo_consulta):
@@ -291,15 +287,14 @@ class Armazenamento():
                 indice_consulta = i
 
         if indice_consulta == None:
-            print('Consulta nao encontrada')
-            return
+            return False
 
         del linhas[indice_consulta]
 
         with open(self.arquivo_consultas, 'w') as f:
             f.writelines(linhas)
         
-        print(f'Consulta de ID {codigo_consulta} removido com sucesso')
+        return True
 
 
     def remover_consulta_do_paciente(self, id_paciente):
@@ -329,6 +324,8 @@ class Armazenamento():
 
         with open(self.arquivo_consultas, 'w') as f:
             f.writelines(linhas)
+
+        print(f'Consultas associadas ao paciente {id_paciente} foram removidas.')
 
 
     def remover_consulta_do_procedimento(self, id_procedimento):


### PR DESCRIPTION
Centralizar mensagens nas classes, removendo de armazenamento.py e main.py. Aproveitando tambem para Adicionar checagem de sucesso antes de registrar logs.